### PR TITLE
Added query and significantly reduced panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ authors = ["Tim <timothyhollabaugh@gmail.com>"]
 downcast-rs = "1.0.3"
 mysql = "14.1.1"
 rpassword = "2.0.0"
-
+serde = "1.0.80"
+serde_derive = "1.0.80"

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -24,12 +24,14 @@ pub enum Value {
     String(String),
 	Boolean(bool),
 }
-pub enum QueryType{
+//Enum for query
+//Shows what type of query along with the data needed for it
+//The data does not include the key becuase it needs Self
+pub enum QueryType<E:Entry>{
 	Lookup,
-	Search,
-	GetAll,
-	PartialSearch,
-	LimitSearch,
+	Search(E::FieldNames, Value, u8), //FieldName for Field being searched, Value for what's being searched
+	GetAll(u8), //Limit
+	PartialSearch(E::FieldNames, Value, u8), //FieldName for Field being searched, Value for what's being searched
 }
 
 impl ToString for Value{
@@ -120,5 +122,5 @@ pub trait Table<E: Entry> {
 	/// When complete, it will replce lookup and search
 	/// If the query does not require a key, input DEFAULT_KEY
 	/// This allows for easy addition of more query types
-	fn query(&self, q: QueryType,  data:Vec<Value>, key: Self::Key) -> Result<Vec<(Self::Key, E)>,String>;
+	fn query(&self, q: QueryType<E>,  key: Option<Self::Key>) -> Result<Vec<(Self::Key, E)>,String>;
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -22,7 +22,16 @@ pub enum Value {
     Integer(i32),
     Float(f32),
     String(String),
+	Boolean(bool),
 }
+pub enum QueryType{
+	Lookup,
+	Search,
+	GetAll,
+	PartialSearch,
+	LimitSearch,
+}
+
 impl ToString for Value{
 	fn to_string(&self) -> String{
 		if let Value::Integer(temp) = self{
@@ -86,7 +95,7 @@ pub trait Table<E: Entry> {
     type Key: Key<E>;
 
     /// Insert an entry into the table. Returns a key for the entry in the table.
-    fn insert(&mut self, entry: E) -> Self::Key;
+    fn insert(&self, entry: E) -> Self::Key;
 
     /// Find a key in the table. Returns Some(Entry) if the entry for the key is in the table, None
     /// otherwise.
@@ -106,4 +115,10 @@ pub trait Table<E: Entry> {
     /// Check whether a given key is in the table. Returns true if the key is in the table,
     /// false otherwise
     fn contains(&self, key: Self::Key) -> bool;
+	
+	/// Generic Query Builder
+	/// When complete, it will replce lookup and search
+	/// If the query does not require a key, input DEFAULT_KEY
+	/// This allows for easy addition of more query types
+	fn query(&self, q: QueryType,  data:Vec<Value>, key: Self::Key) -> Result<Vec<(Self::Key, E)>,String>;
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -95,7 +95,7 @@ pub trait Table<E: Entry> {
     type Key: Key<E>;
 
     /// Insert an entry into the table. Returns a key for the entry in the table.
-    fn insert(&self, entry: E) -> Self::Key;
+    fn insert(&mut self, entry: E) -> Self::Key;
 
     /// Find a key in the table. Returns Some(Entry) if the entry for the key is in the table, None
     /// otherwise.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -24,14 +24,34 @@ pub enum Value {
     String(String),
 	Boolean(bool),
 }
+
 //Enum for query
 //Shows what type of query along with the data needed for it
 //The data does not include the key becuase it needs Self
+
+
+//Advanced search (multiple fields, full or partial)
 pub enum QueryType<E:Entry>{
+	//Doesn't require input, but it does need a key in the query call
 	Lookup,
-	Search(E::FieldNames, Value, u8), //FieldName for Field being searched, Value for what's being searched
-	GetAll(u8), //Limit
-	PartialSearch(E::FieldNames, Value, u8), //FieldName for Field being searched, Value for what's being searched
+	//FieldName for Field being searched, Value for what's being searched
+	//Field to sort by, Direction to sort in, page number
+	Search(E::FieldNames, Value, u16,E::FieldNames,SortDirection,u16), 
+	//Limit, Field to sort by, Direction to sort in, page number
+	//Field to sort by, Direction to sort in, page number
+	GetAll(u16,E::FieldNames,SortDirection,u16), 
+	//FieldName for Field being searched, Value for what's being searched
+	// Field to sort by, Direction to sort in, page number
+	PartialSearch(E::FieldNames, Value, u16,E::FieldNames,SortDirection,u16),
+	//FieldNames for Fields being searched, Values for what's being searched (in the same order)
+	// Field to sort by, Direction to sort in, page number
+	MultiSearch(Vec<E::FieldNames>, Vec<Value>, u16,E::FieldNames,SortDirection,u16),
+	
+}
+//This enum is to determine direction in QueryType
+pub enum SortDirection {
+	Asc, //Ascending
+	Desc //Descending
 }
 
 impl ToString for Value{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,6 @@ pub mod tests;
 pub mod vec_table;
 pub mod my_types;
 pub mod mysql_test;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;

--- a/src/my_types.rs
+++ b/src/my_types.rs
@@ -305,7 +305,7 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 				}
 				let lim_cmd = " ORDER BY ".to_string() + &sort_field.to_string()+&sort_string+"LIMIT "+&start_limit.to_string()+", "+&limit.to_string();
 
-				let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&field.to_owned().to_string()+ " = " + &val.to_owned().to_string() + &lim_cmd;
+				let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&field.to_owned().to_string()+ " = " + &ivalue_to_mystring(&val) + &lim_cmd;
 		
 				let vec_result: Result<Vec<(MysqlTableKey, E)>,String> = con.prep_exec(cmd,()).map(|result|{
 					result.map(|x| x.unwrap()).map(|row|{
@@ -419,7 +419,7 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 				let lim_cmd = " ORDER BY ".to_string() + &sort_field.to_string()+&sort_string+"LIMIT "+&start_limit.to_string()+", "+&limit.to_string();
 				
 				//Make and send the command
-				let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&field.to_owned().to_string()+ " LIKE " + &search_val + &lim_cmd;
+				let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&field.to_owned().to_string()+ " LIKE " + &ivalue_to_mystring(&val) + &lim_cmd;
 				let vec_result: Result<Vec<(MysqlTableKey, E)>,String> = con.prep_exec(cmd,()).map(|result|{
 					result.map(|x| x.unwrap()).map(|row|{
 						//Iterates through each row, panics if the schema is not followed

--- a/src/my_types.rs
+++ b/src/my_types.rs
@@ -36,16 +36,23 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 		con.query(cmd_db).unwrap();//Sending known command
 		
 		let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&self.key_name+ " = " + &key.id.to_string();
-		let vec_result: Vec<Vec<my::Value>> = con.prep_exec(cmd,())
+		let vec_result: Result<Vec<Vec<my::Value>>,my::Error> = con.prep_exec(cmd,())
 			.map(|result|{
-				result.map(|x| x.unwrap()).map(|row|{//Panics if schema is not followed
+				result.map(|x| 
+					match x {
+						Err(_e) => return Err("Bad Query".to_string()),
+						Ok(y) => Ok(y),
+					}).map(|row|{
 					//Iterates through each row
-					let vec_data = my::Row::unwrap(row); //Returns a vector of my::Values for each row
-					//Panics if schema is not followed
-					vec_data //The order of the vector depends on the order inside the mySQL database
+					my::Row::unwrap(row.unwrap()) //Unwraps after checking its okay
+					//Returns a vector of my::Values for each row in the same order as DB
 				}).collect()
-			}).unwrap();//Panics if schema is not followed
-		let this_result =&vec_result[0]; //Saves the desired entry to a seperate vec
+			});
+		let vec_result_okay = match vec_result{
+			Ok(x) => x,
+			Err(_) => return None //Converts my::Error to string
+		};
+		let this_result =&vec_result_okay[0]; //Saves the desired entry to a seperate vec
 		//Change the my::Value to interface::Value, start by declaring needed variables
 		let mut the_result = Vec::new();
 		let mut i:usize = 0;
@@ -56,21 +63,17 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 			let temp = myvalue_to_ivalue(&this_result[i]);
 			//Check the result for an error
 			match temp{
-				Err(_err_string) => good_value = false,
-				_ => the_result.push(temp.unwrap()), //unwraps after checking it's okay, so it won't panic
+				Ok(x) => the_result.push(x),
+				Err(_) => good_value = false,
 			};
 			i=i+1;
 		}
-
-		
 		// Make a return based on the presence of an error
 		match &good_value {
-			true=> Some(Entry::from_fields(&the_result[1..]).unwrap()),//unwraps after checking it's okay, so it won't panic
-			_ => None
+			true  => Some(Entry::from_fields(&the_result[1..]).unwrap()),//unwraps after checking it's okay, so it won't panic
+			false => None
 		}
-
 	}
-
 	//Inserts a new row into the table and returns a key
 	//Uses QueryResult.last_insert_id to get a key back
 	fn insert(&mut self, entry: E) -> Self::Key{
@@ -81,11 +84,6 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 		let cmd_db = "USE ".to_owned() + &self.db_name;//Open the proper database
 		con.query(cmd_db).unwrap();//Sending known command
 		
-		
-		let _values :String = String::new(); //Create blank strings to hold to the fields and data
-		let _data :String = String::new();
-		//Create one big string for all data from Vec<interface:Value>
-		let _entry_string = String::new();
 		let entry_vec = entry.get_fields();//Get the data as a string, must be ordered in the same way as fields
 		let entry_vec_string :Vec<String>= entry_vec.iter().map(|x| {
 			ivalue_to_mystring(x)
@@ -113,14 +111,12 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 			MysqlTableKey{id:id, valid:true}
 			}).collect()
 		}).unwrap();//Sending known command, will not panic
-		
 		//Return a value based on good results
 		if qr{
 			this_key[0]
 		} else{
 			MysqlTableKey{id: 0, valid:false}//Returns 0 and an indicator of a bad key
 		}
-
 	}	
 	fn search(&self, field_name: E::FieldNames, field_value: interface::Value) -> Result<Vec<(Self::Key, E)>,String>{
 		//SELECT * FROM tb_name WHERE field_name = field_value
@@ -131,55 +127,39 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 		con.query(cmd_db).unwrap();//Sending known command
 		
 		let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&field_name.to_string()+ " = " + &field_value.to_string();
-		let vec_result: Vec<Vec<my::Value>> = con.prep_exec(cmd,())
-			.map(|result|{
-				result.map(|x| x.unwrap()).map(|row|{
-					//Iterates through each row, panics if the schema is not followed
-					let vec_data = my::Row::unwrap(row); //Returns a vector of my::Values for each row
-					vec_data //The order of the vector depends on the order inside the mySQL database
-				}).collect()
-			}).unwrap();//Panics if schema is not followed
-		let mut final_result: Vec<(Self::Key, E)> = Vec::new();
-		let mut j:usize = 0;
-		let mut good_value = true;
-		let mut err_string = "Failed to convert mySQL Value".to_string();
-		while j <vec_result.len(){
-			let this_result =&vec_result[j]; //Saves the desired entry to a seperate vec
-			//Change the my::Value to interface::Value
-			let mut the_result = Vec::new();
-			let mut i:usize = 0;
-			while i < this_result.len() {
-				let temp = myvalue_to_ivalue(&this_result[i]);
-				//Check the result for an error
-				match temp{
-					Err(_err_string) => good_value = false,
-					_ => the_result.push(temp.unwrap()), //unwraps after checking it's okay, so it won't panic
+		let vec_result: Result<Result<Vec<(MysqlTableKey, E)>,String>,my::Error> = con.prep_exec(cmd,()).map(|result|{
+			result.map(|x| {
+				match x {
+					Err(_e) => return Err("Bad Query".to_string()),
+					Ok(y) => Ok(y),
+				}
+			})
+			.map(|row|{
+				let vec_data = my::Row::unwrap(row.unwrap());//Unwraps after checking its okay
+				//Returns a vector of my::Values for each row
+				let iter_data = vec_data.iter(); 
+				let ivec : Vec<interface::Value> = iter_data.map(|r|{
+					myvalue_to_ivalue(r).unwrap() //Changes each my::Value to interface::Value
+					//Panics if the database stores data not recognized by myvalue_to_ivalue
+				}).collect();
+				let this_entry_result = E::from_fields(&ivec[1..]);
+				let this_entry = match this_entry_result {
+					Err(string) => return Err(string),
+					Ok(x) => x
+				}; //Only goes through with the let if the result is okay
+				let this_key = MysqlTableKey {
+					id: ivec[0].to_owned().itry_into().unwrap(), 
+					//Panics if the database's first column isn't the key, which it *should* be
+					valid: true
 				};
-				i=i+1;
-			}
-			// Make a return based on the presence of an error
-			match &good_value {
-				true=> {
-					let my_key= MysqlTableKey{
-						id: my::from_value(this_result[0].to_owned()),
-						valid:true
-					};
-					let end_result:Result<E,String> = Entry::from_fields(&the_result[1..]);
-					match &end_result{
-						Ok(_e) => final_result.push((my_key,end_result.clone().unwrap())),//unwraps after checking it's okay, so it won't panic
-						_=> err_string = "Database did not return a valid entry".to_string(),
-					};					
-				},
-				_ => err_string = "Failed to convert mySQL Value".to_string(),
-			};
-			j=j+1;
-		}//End of while loop
-		match &good_value {
-			true => Ok(final_result),
-			_=> Err(err_string),
+				Ok((this_key,this_entry))
+			}).collect()
+		});
+		match vec_result {
+			Ok(x) => x,
+			Err(y) => Err(y.to_string()),
 		}
 	}
-	
 	fn update(&self, key: Self::Key, entry: E)-> Result<(), String>{
 		//UPDATE tb_name SET field 1= entry 1, field 2 = entry 2, ... WHERE id = key
 		//Always start with opening mysql
@@ -201,18 +181,14 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 			//Will not panic since ivalue_to_mystring will always return a valid string
 		}
 		let set = set_vec[..].join(", ");	//Combines the set_vec (as a slice) into one string seperated by ,
-		
-		//Create string for cmd
+		//Create string for cmd and send
 		let cmd = "UPDATE ".to_string() + &self.tb_name + " SET " + &set + " WHERE "+ &self.key_name + " = " +&key.id.to_string();
+		let qr = con.query(cmd);//Send cmd and see if it is good
 		
-		//Send cmd and see if it is good
-		let qr = con.query(cmd);
-		
-		let f : Result <(), String>= match qr {
-        Ok(_query_result) => Ok(()),
-        Err(_error) => Err("There was a problem updating the user, please consult sysadmin".to_string()),
-		};
-    	f
+		match qr {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e.to_string()),//Converts my::Error to a string
+		}
 	}
 	
     fn remove(&mut self, key: Self::Key) -> Result<(), String>{
@@ -222,19 +198,15 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 		let mut con = self.pool.get_conn().unwrap();//Open connection to mySQL
 		let cmd_db = "USE ".to_owned() + &self.db_name;//Open the proper database
 		con.query(cmd_db).unwrap();//Sending known command
-		
-		//let mut cmd = String::new();
+	
 		let cmd = "DELETE FROM ".to_string() + &self.tb_name + " WHERE " + &self.key_name + " = " +&key.id.to_string();
 		let qr = con.query(cmd);
 		
-		let f : Result <(), String>= match qr {
-			Ok(_query_result) => Ok(()),
-			Err(_error) => Err("There was a problem deleting the user, please consult sysadmin".to_string()),
-		};
-    	f
-	
+		match qr {
+			Ok(_) => Ok(()),
+			Err(_) => Err("There was a problem deleting the user, please consult sysadmin".to_string()),
+		}	
 	}
-	
     fn contains(&self, key: Self::Key) -> bool{
 		//Same as lookup but returns a bool if the query result returns anything
 		//Always start with opening mysql
@@ -242,24 +214,31 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 		let mut con = self.pool.get_conn().unwrap();//Open connection to mySQL
 		let cmd_db = "USE ".to_owned() + &self.db_name;//Open the proper database
 		con.query(cmd_db).unwrap();//Sending known command
-		
+		//Create command to execute in mySQL
 		let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&self.key_name+ " = " + &key.id.to_string();
-		let vec_result: Vec<Vec<my::Value>> = con.prep_exec(cmd,())
+		let vec_result: Result<Vec<Vec<my::Value>>,my::Error> = con.prep_exec(cmd,())
 			.map(|result|{
-				result.map(|x| x.unwrap()).map(|row|{
+				result.map(|x| 
+					match x {
+						Ok(y) => Ok(y),
+						Err(_) => return Err("Bad Query".to_string()),
+					}).map(|row|{
 					//Iterates through each row, will panic if schema is not followed
-					let vec_data = my::Row::unwrap(row); //Returns a vector of my::Values for each row
+					let vec_data = my::Row::unwrap(row.unwrap()); //Unwraps after checking its okay
+					//Returns a vector of my::Values for each row
 					vec_data //The order of the vector depends on the order inside the mySQL database
 				}).collect()
-			}).unwrap();//Will panic if schema is not followed
-		if vec_result.len() != 0 {
+			});
+		match &vec_result {
+			Ok(x) => x,
+			Err(_) => return false,
+		};
+		if vec_result.unwrap().len() != 0 { //Unwraps after checking its okay
 			true
 		}else{
 			false
 		}
 	}
-	
-	//Make a MysqlTableKey<User>::new({struct data});
 	fn query(&self, q: QueryType<E>, key: Option<Self::Key>) -> Result<Vec<(Self::Key, E)>,String>{
 		// Uses query type to decide wihch function to use and get the neccessary data
 		//Because of the need for Self, the key is taken seperately, but isn't always needed
@@ -269,7 +248,6 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 				if key == None {
 					return Err("Must have a key".to_string())
 				}
-				
 				let result = self.lookup(key.unwrap()); //Unwraps after checking its okay
 				match result {
 					Some(this_key) => {
@@ -281,7 +259,6 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 						Err("Invalid key".to_string())
 					}
 				}
-			
 			},
 			QueryType::Search(field,val,lim,sort_field,sort_dir, pg)=>{
 				//No key required
@@ -291,7 +268,7 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 				let mut con = self.pool.get_conn().unwrap();//Open connection to mySQL
 				let cmd_db = "USE ".to_owned() + &self.db_name;//Open the proper database
 				con.query(cmd_db).unwrap();//Sending known command
-				
+				//Establish Limit
 				let mut limit = lim;
 				if limit > &MAX_LIMIT {
 					limit = &MAX_LIMIT;
@@ -303,33 +280,45 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 					interface::SortDirection::Asc =>  sort_string = " ASC ".to_string(),
 					interface::SortDirection::Desc => sort_string = " DESC ".to_string(),
 				}
-				let lim_cmd = " ORDER BY ".to_string() + &sort_field.to_string()+&sort_string+"LIMIT "+&start_limit.to_string()+", "+&limit.to_string();
+				let lim_cmd = " ORDER BY ".to_string() + &sort_field.to_string()+&sort_string+
+					"LIMIT "+&start_limit.to_string()+", "+&limit.to_string();
 
-				let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&field.to_owned().to_string()+ " = " + &ivalue_to_mystring(&val) + &lim_cmd;
+				let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&field.to_owned().to_string()+
+					" = " + &ivalue_to_mystring(&val) + &lim_cmd;
 		
-				let vec_result: Result<Vec<(MysqlTableKey, E)>,String> = con.prep_exec(cmd,()).map(|result|{
-					result.map(|x| x.unwrap()).map(|row|{
+				let vec_result: Result<Result<Vec<(MysqlTableKey, E)>,String>,my::Error> = con.prep_exec(cmd,()).map(|result|{
+					result.map(|x| {
+						match x {
+							Ok(y) => Ok(y),						
+							Err(_) => return Err("Bad Query".to_string()),
+						}
+					})
+					.map(|row|{
 						//Iterates through each row, panics if the schema is not followed
-						let vec_data = my::Row::unwrap(row);//Returns a vector of my::Values for each row
+						let vec_data = my::Row::unwrap(row.unwrap());//Unwraps after checking its okay
+						//Returns a vector of my::Values for each row
 						let iter_data = vec_data.iter(); 
 						let ivec : Vec<interface::Value> = iter_data.map(|r|{
 							myvalue_to_ivalue(r).unwrap() //Changes each my::Value to interface::Value
+							//Panics if the database stores invalid data
 						}).collect();
 						let this_entry_result = E::from_fields(&ivec[1..]);
-						match this_entry_result {
+						let this_entry = match this_entry_result {
 							Err(string) => return Err(string),
-							Ok(_) => ()
-						}
-						let this_entry = this_entry_result.unwrap(); //Unwraps after checking its okay
+							Ok(x) => x
+						};
 						let this_key = MysqlTableKey {
 							id: ivec[0].to_owned().itry_into().unwrap(),
+							//Panics if the database's first column isn't the key, which it *should* be
 							valid: true
 						};
 						Ok((this_key,this_entry))
 					}).collect()
-				}).unwrap();//Panics if schema is not followed
-					vec_result
-				
+				});
+				match vec_result {
+					Ok(x) => x,
+					Err(y) => Err(y.to_string()),
+				}
 			},
 			interface::QueryType::GetAll(lim,sort_field,sort_dir, pg)=>{
 				//No key required
@@ -341,7 +330,7 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 				let mut con = self.pool.get_conn().unwrap();//Open connection to mySQL
 				let cmd_db = "USE ".to_owned() + &self.db_name;//Open the proper database
 				con.query(cmd_db).unwrap();//Sending known command
-				
+				//Establish limit
 				let mut limit = lim;
 				if limit > &MAX_LIMIT {
 					limit = &MAX_LIMIT;
@@ -351,19 +340,26 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 				let sort_string: String;
 				match &sort_dir {
 					interface::SortDirection::Asc =>  sort_string = " ASC ".to_string(),
-					interface::SortDirection::Desc => sort_string = " DESC".to_string(),
+					interface::SortDirection::Desc => sort_string = " DESC ".to_string(),
 				}
-				let lim_cmd = " ORDER BY ".to_string() + &sort_field.to_string()+&sort_string+"LIMIT "+&start_limit.to_string()+", "+&limit.to_string();
-			
-				
+				let lim_cmd = " ORDER BY ".to_string() + &sort_field.to_string()+&sort_string+"LIMIT "
+					+&start_limit.to_string()+", "+&limit.to_string();
+				//Create command to send to mySQL
 				let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ &lim_cmd;
-				let vec_result: Result<Vec<(MysqlTableKey, E)>,String> = con.prep_exec(cmd,()).map(|result|{
-					result.map(|x| x.unwrap()).map(|row|{
-						//Iterates through each row, panics if the schema is not followed
-						let vec_data = my::Row::unwrap(row);//Returns a vector of my::Values for each row
+				let vec_result: Result<Result<Vec<(MysqlTableKey, E)>,String>,my::Error> = con.prep_exec(cmd,()).map(|result|{
+					result.map(|x| {
+						match x {
+							Err(_e) => return Err("Bad Query".to_string()),
+							Ok(y) => Ok(y),
+						}
+					})
+					.map(|row|{
+						let vec_data = my::Row::unwrap(row.unwrap());//Unwraps after checking its okay
+						//Returns a vector of my::Values for each row
 						let iter_data = vec_data.iter(); 
 						let ivec : Vec<interface::Value> = iter_data.map(|r|{
 							myvalue_to_ivalue(r).unwrap() //Changes each my::Value to interface::Value
+							//Panics if the database stores invalid data
 						}).collect();
 						let this_entry_result = E::from_fields(&ivec[1..]);
 						match this_entry_result {
@@ -377,8 +373,11 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 						};
 						Ok((this_key,this_entry))
 					}).collect()
-				}).unwrap();//Panics if schema is not followed
-					vec_result
+				});
+				match vec_result {
+					Ok(x) => x,
+					Err(y) => Err(y.to_string()),
+				}
 			},
 			QueryType::PartialSearch(field,val,lim,sort_field,sort_dir, pg)=>{
 				//SELECT * FROM tb_name WHERE field_name LIKE *field_value*
@@ -411,23 +410,29 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 				}
 				let start_limit = limit*(pg-1);
 				//Sort and limit string
-				let sort_string: String;
-				match &sort_dir {
-					interface::SortDirection::Asc =>  sort_string = " ASC ".to_string(),
-					interface::SortDirection::Desc => sort_string = " DESC ".to_string(),
-				}
-				let lim_cmd = " ORDER BY ".to_string() + &sort_field.to_string()+&sort_string+"LIMIT "+&start_limit.to_string()+", "+&limit.to_string();
-				
+				let sort_string = match &sort_dir {
+					interface::SortDirection::Asc =>  " ASC ".to_string(),
+					interface::SortDirection::Desc => " DESC ".to_string(),
+				};
+				let lim_cmd = " ORDER BY ".to_string() + &sort_field.to_string()+&sort_string+
+					"LIMIT "+&start_limit.to_string()+", "+&limit.to_string();
 				//Make and send the command
-				let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&field.to_owned().to_string()+ " LIKE " + &ivalue_to_mystring(&val) + &lim_cmd;
-				let vec_result: Result<Vec<(MysqlTableKey, E)>,String> = con.prep_exec(cmd,()).map(|result|{
-					result.map(|x| x.unwrap()).map(|row|{
-						//Iterates through each row, panics if the schema is not followed
-						let vec_data = my::Row::unwrap(row);//Returns a vector of my::Values for each row
+				let cmd = "SELECT * FROM ".to_string()+&self.tb_name+ " WHERE "+&field.to_owned().to_string()
+					+ " LIKE " + &search_val + &lim_cmd;
+				let vec_result: Result<Result<Vec<(MysqlTableKey, E)>,String>,my::Error> = con.prep_exec(cmd,()).map(|result|{
+					result.map(|x| {
+						match x {
+							Err(_e) => return Err("Bad Query".to_string()),
+							Ok(y) => Ok(y),
+						}
+					})
+					.map(|row|{
+						let vec_data = my::Row::unwrap(row.unwrap());//Unwraps after checking its okay
+						//Returns a vector of my::Values for each row
 						let iter_data = vec_data.iter(); 
 						let ivec : Vec<interface::Value> = iter_data.map(|r|{
-							let temp = myvalue_to_ivalue(r).unwrap(); //Changes each my::Value to interface::Value
-							temp
+							myvalue_to_ivalue(r).unwrap() //Changes each my::Value to interface::Value
+							//Panics if the database stores invalid data
 						}).collect();
 						let this_entry_result = E::from_fields(&ivec[1..]);
 						match this_entry_result {
@@ -442,9 +447,11 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 
 						Ok((this_key,this_entry))
 					}).collect()
-				}).unwrap();//Panics if schema is not followed
-					vec_result
-			
+				});
+				match vec_result {
+					Ok(x) => x,
+					Err(y) => Err(y.to_string()), //Converts the my::Error into a string
+				}
 			},
 			QueryType::MultiSearch(field_vec, val_vec, lim,sort_field,sort_dir,pg)=>{
 				//No key required
@@ -479,38 +486,39 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 				}
 				let search_cmd = search_vec.join(" AND ");
 				let cmd = "SELECT * FROM ".to_string() + &self.tb_name+ " WHERE " +&search_cmd + &lim_cmd;
-				println!("{}",cmd);
-				let vec_result: Result<Vec<(MysqlTableKey, E)>,String> = con.prep_exec(cmd,()).map(|result|{
-					result.map(|x| x.unwrap()).map(|row|{
-						//Iterates through each row, panics if the schema is not followed
-						let vec_data = my::Row::unwrap(row);//Returns a vector of my::Values for each row
+				let vec_result: Result<Result<Vec<(MysqlTableKey, E)>,String>,my::Error> = con.prep_exec(cmd,()).map(|result|{
+					result.map(|x| {
+						match x {
+							Err(_e) => return Err("Bad Query".to_string()),
+							Ok(y) => Ok(y),
+						}
+					})
+					.map(|row|{
+						let vec_data = my::Row::unwrap(row.unwrap());//Unwraps after checking its okay
+						//Returns a vector of my::Values for each row
 						let iter_data = vec_data.iter(); 
 						let ivec : Vec<interface::Value> = iter_data.map(|r|{
 							myvalue_to_ivalue(r).unwrap() //Changes each my::Value to interface::Value
+							//Panics if the database stores invalid data
 						}).collect();
 						let this_entry_result = E::from_fields(&ivec[1..]);
-						match this_entry_result {
+						let this_entry = match this_entry_result {
 							Err(string) => return Err(string),
-							Ok(_) => ()
-						}
-						let this_entry = this_entry_result.unwrap(); //Unwraps after checking its okay
+							Ok(x) => x
+						};
 						let this_key = MysqlTableKey {
 							id: ivec[0].to_owned().itry_into().unwrap(),
 							valid: true
 						};
-						println!("{:?}",ivec);
 						Ok((this_key,this_entry))
 					}).collect()
-				}).unwrap();//Panics if schema is not followed
-					vec_result
-				
-				
-				
+				});
+				match vec_result {
+					Ok(x) => x,
+					Err(y) => Err(y.to_string()), //Converts my::Error to a string
+				}
 			},
-		
 		}
-	
-	
 	}
 }
 //New function and supporting functions for query
@@ -526,7 +534,6 @@ impl <E:Entry>MysqlTable<E>{
 		}
 	}
 }
-
 //Generic functions for mySQL
 fn myvalue_to_ivalue(start:&my::Value)->Result<interface::Value,String>{
 	let _temp :interface::Value;
@@ -535,7 +542,6 @@ fn myvalue_to_ivalue(start:&my::Value)->Result<interface::Value,String>{
 		my::Value::Int(_i64) 	=> Ok(interface::Value::Integer	(my::from_value(start.to_owned()))),
 		my::Value::Float(_f64)	=> Ok(interface::Value::Float	(my::from_value(start.to_owned()))),
 		my::Value::Bytes(_vec)	=> Ok(interface::Value::String	(my::from_value(start.to_owned()))),
-		//PUT IN BOOLS HERE
 		_ => Err("Failed to convert mySQL Value".to_string()),
 	}
 }
@@ -547,7 +553,7 @@ fn ivalue_to_mystring(data: &interface::Value)->String{
 		//Strings need quotes around them. This assumes that all other characters have already been escaped
 		interface::Value::String(_string) => {
 			let temp :Vec<String> = data.to_owned().to_string().split('\'').map({|x|
-				x.to_string() //Creates a gap wherever there was a ' (deletes the ')
+				x.trim().to_string() //Creates a gap wherever there was a ' (deletes the ')
 			}).collect();
 			"'".to_string() + &temp.join("\\\'") + "'"//Adds a \' in between each gap
 		},
@@ -565,13 +571,10 @@ pub fn open_mysql(user: String, pass:String)-> Result<my::Pool,String>{
 	let optcon = optbuild;
 	let p = my::Pool::new(optcon);
 	match p{
-		Ok(_) => Ok(p.unwrap()),//unwraps after checking it's okay, so it won't panic
+		Ok(k) => Ok(k),
 		Err(_) => Err("Username and password do not match".to_string())
 	}
 }
-
-
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct MysqlTableKey{
 	pub id: i32,

--- a/src/my_types.rs
+++ b/src/my_types.rs
@@ -69,7 +69,7 @@ impl <E:Entry>Table<E> for MysqlTable<E>{
 
 	//Inserts a new row into the table and returns a key
 	//Uses QueryResult.last_insert_id to get a key back
-	fn insert(&self, entry: E) -> Self::Key{
+	fn insert(&mut self, entry: E) -> Self::Key{
 		//Always start with opening mysql
 		//Opening mysql will never panic if done with the openmysql function
 		let mut con = self.pool.get_conn().unwrap();//Open connection to mySQL

--- a/src/mysql_test.rs
+++ b/src/mysql_test.rs
@@ -137,38 +137,6 @@ Columns in User
 	}
 
 	#[test]
-	fn simple_mysql_test(){
-		println!("enter username: ");
-		let mut user = String::new();
-		io::stdin().read_line(&mut user).expect("Failed to read line");
-		user = user.trim().to_string();
-		println!("{}'s password: ",user);
-		let pass = rpassword::read_password().unwrap().trim().to_string();
-		let pool = my_types::open_mysql(user,pass).unwrap();//Open mySQL
-	
-		//Change this to my_types::MysqlTableKey<User>::new({struct data});
-		let mut user_table = my_types::MysqlTable::<User>::new(pool);
-			user_table.tb_name  = "User".to_string();
-			user_table.db_name  = "dbTest".to_string();
-			user_table.key_name = "userID".to_string();
-		//Create a student to send to the database
-		//All strings in the user must have a \' to indicate to mySQL that it is indeed a string
-		let nick_kz = User{
-			firstname:"Nick".to_string(),
-			lastname:"Kluzynski".to_string(),
-			email: "kluzynskn6@students.rowan.edu".to_string(),
-			bannerID: 916181533,
-			
-		};
-		let nick_key:my_types::MysqlTableKey = Some(user_table.insert(nick_kz)).unwrap();
-		assert!(nick_key.valid);
-	
-		let _nick_del = user_table.remove(nick_key).unwrap();//Delete Nick from db so it doesn't get clogged
-	
-	}
-	
-	
-	#[test]
 	fn full_mysql_test(){
 		println!("enter username: ");
 		let mut user = String::new();
@@ -202,7 +170,7 @@ Columns in User
 			bannerID: 916181533,
 			
 		};
-
+		//Testing basic functions
 		let nick_key:my_types::MysqlTableKey = Some(user_table.insert(nick_kz)).unwrap();
 		assert!(nick_key.valid);
 		
@@ -218,6 +186,19 @@ Columns in User
 		let nick_3 = user_table.search(UserFields::firstname,interface::Value::String("\'Nicholas\'".to_string())).unwrap()[0].to_owned().1;//Only saves the entry of the first result
 		assert_eq!(nick_3.lastname,"Kluzynski");
 
+		//Testing query
+		let q_nick = user_table.query(interface::QueryType::Lookup,Some(nick_key)).unwrap();
+		assert_eq!(q_nick[0].1.firstname,"Nicholas");
+		
+		let q_parsearch = user_table.query(interface::QueryType::PartialSearch(UserFields::email,interface::Value::String("@".to_string()),2),None).unwrap();
+		assert_eq!(q_parsearch.len(),2);
+		
+		let q_all = user_table.query(interface::QueryType::GetAll(3),None).unwrap();
+		assert_eq!(q_all.len(),3);
+
+		
+		
+		
 		let _nick_del = user_table.remove(nick_key).unwrap();//Delete Nick from db so it doesn't get clogged
 
 	}

--- a/src/mysql_test.rs
+++ b/src/mysql_test.rs
@@ -190,14 +190,16 @@ Columns in User
 		let q_nick = user_table.query(interface::QueryType::Lookup,Some(nick_key)).unwrap();
 		assert_eq!(q_nick[0].1.firstname,"Nicholas");
 		
-		let q_parsearch = user_table.query(interface::QueryType::PartialSearch(UserFields::email,interface::Value::String("@".to_string()),2),None).unwrap();
+		let q_parsearch = user_table.query(interface::QueryType::PartialSearch(UserFields::email,interface::Value::String("@".to_string()),2,UserFields::firstname, interface::SortDirection::Asc, 1),None).unwrap();
 		assert_eq!(q_parsearch.len(),2);
 		
-		let q_all = user_table.query(interface::QueryType::GetAll(3),None).unwrap();
+		let q_all = user_table.query(interface::QueryType::GetAll(3,UserFields::firstname, interface::SortDirection::Asc, 1),None).unwrap();
 		assert_eq!(q_all.len(),3);
 
-		
-		
+		let field_vec = vec!(UserFields::firstname, UserFields::lastname);
+		let val_vec = vec!(interface::Value::String("Nick".to_string()),interface::Value::String("Kluzynski".to_string()));
+		let q_multi = user_table.query(interface::QueryType::MultiSearch(field_vec, val_vec,2,UserFields::bannerID,interface::SortDirection::Asc,1),None).unwrap();
+		assert_eq!(q_multi[0].1.firstname, "Nick");
 		
 		let _nick_del = user_table.remove(nick_key).unwrap();//Delete Nick from db so it doesn't get clogged
 

--- a/src/mysql_test.rs
+++ b/src/mysql_test.rs
@@ -11,6 +11,7 @@ mod mysql_test{
 	use std::fmt::Display;
 	use interface::ITryInto;
 	use std::io;
+	use std::marker::PhantomData;
 
 //The following is an example of how to use the my_types to both send and recieve data from mySQL.
 //Because the tables rely on follwing the schema very closely, here is the schema for this example
@@ -47,10 +48,9 @@ Columns in User
 		email:String,
 		bannerID: i32
 	}
-	//Even though it is not in the struct, it should still be in UserFields so mySQL knows what the key is called
+	
 	#[derive(PartialEq, Clone, Copy, Debug)]
 	enum UserFields {
-		userID,
 		firstname,
 		lastname,
 		email,
@@ -63,7 +63,6 @@ Columns in User
 
 		fn from_str(s: &str) -> Result<Self, Self::Err> {
 			match s {
-				"userID" 	=> Ok(UserFields::userID),
 				"firstname"	=> Ok(UserFields::firstname),
 				"lastname"	=> Ok(UserFields::lastname),
 				"email"		=> Ok(UserFields::email),
@@ -75,7 +74,6 @@ Columns in User
 	impl Display for UserFields {
 		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 			match self {
-				UserFields::userID		=>write!(f,"userID"),
 				UserFields::firstname	=>write!(f,"firstname"),
 				UserFields::lastname	=>write!(f,"lastname"),
 				UserFields::email		=>write!(f,"email"),
@@ -112,7 +110,6 @@ Columns in User
 		}
 		fn get_field_names() -> Vec<Self::FieldNames>{
 			vec![
-				UserFields::userID,
 				UserFields::firstname,
 				UserFields::lastname,
 				UserFields::email,
@@ -144,24 +141,16 @@ Columns in User
 		println!("enter username: ");
 		let mut user = String::new();
 		io::stdin().read_line(&mut user).expect("Failed to read line");
+		user = user.trim().to_string();
 		println!("{}'s password: ",user);
-		let pass = rpassword::read_password().unwrap();
+		let pass = rpassword::read_password().unwrap().trim().to_string();
 		let pool = my_types::open_mysql(user,pass).unwrap();//Open mySQL
 	
-		let fieldvec = vec![
-			UserFields::firstname,
-			UserFields::lastname,
-			UserFields::email,
-			UserFields::bannerID
-		];//Create a Vec<String> for the fields
-		let mut user_table: my_types::MysqlTable<User>= my_types::MysqlTable {
-			tb_name: "User".to_string(),
-			db_name: "dbTest".to_string(),
-			key_name: UserFields::userID,
-			pool:pool, 
-			field: fieldvec,
-		};
-		assert_eq!(user_table.field[0].to_string(),"firstname");
+		//Change this to my_types::MysqlTableKey<User>::new({struct data});
+		let mut user_table = my_types::MysqlTable::<User>::new(pool);
+			user_table.tb_name  = "User".to_string();
+			user_table.db_name  = "dbTest".to_string();
+			user_table.key_name = "userID".to_string();
 		//Create a student to send to the database
 		//All strings in the user must have a \' to indicate to mySQL that it is indeed a string
 		let nick_kz = User{
@@ -184,24 +173,19 @@ Columns in User
 		println!("enter username: ");
 		let mut user = String::new();
 		io::stdin().read_line(&mut user).expect("Failed to read line");
+		user = user.trim().to_string();
 		println!("{}'s password: ",user);
-		let pass = rpassword::read_password().unwrap();
+		let pass = rpassword::read_password().unwrap().trim().to_string();
 		let pool = my_types::open_mysql(user,pass).unwrap();//Open mySQL
 	
-		let fieldvec = vec![
-			UserFields::firstname,
-			UserFields::lastname,
-			UserFields::email,
-			UserFields::bannerID
-		];//Create a Vec<String> for the fields
 		let mut user_table: my_types::MysqlTable<User>= my_types::MysqlTable {
 			tb_name: "User".to_string(),
 			db_name: "dbTest".to_string(),
-			key_name: UserFields::userID,
+			key_name: "userID".to_string(),
 			pool:pool, 
-			field: fieldvec,
+			phantom: PhantomData,
 		};
-		assert_eq!(user_table.field[0].to_string(),"firstname");
+	
 		//Create a student to send to the database
 		let nick_kz = User{
 			firstname:"Nick".to_string(),

--- a/src/vec_table.rs
+++ b/src/vec_table.rs
@@ -3,6 +3,7 @@ use interface::Entry;
 use interface::Key;
 use interface::Table;
 use interface::Value;
+use interface::QueryType;
 
 /**
  *  A key for a VecTable
@@ -45,11 +46,17 @@ impl<E: Entry> Table<E> for VecTable<E> {
 
     type Key = VecTableKey;
 
-    fn insert(&mut self, entry: E) -> Self::Key {
-        self.vector.push((self.next_key, entry));
+    fn insert(&self, entry: E) -> Self::Key {
+        unimplemented!();
+		/*
+		//Commenting this out since it needs a mutable reference. 
+		//As in you can only use this once, and never again.
+		//Yeah nope
+		self.vector.push((self.next_key, entry));
         let key = VecTableKey { id: self.next_key };
         self.next_key += 1;
         key
+		*/
     }
 
     fn lookup(&self, key: Self::Key) -> Option<E> {
@@ -63,6 +70,9 @@ impl<E: Entry> Table<E> for VecTable<E> {
     }
 
 	fn update(&self, _key: Self::Key, _entry: E)-> Result<(), String>{
+		unimplemented!();
+	}
+	fn query(&self, _q: QueryType,  _data:Vec<Value>, _key: Self::Key) -> Result<Vec<(Self::Key, E)>,String>{
 		unimplemented!();
 	}
 	

--- a/src/vec_table.rs
+++ b/src/vec_table.rs
@@ -66,7 +66,7 @@ impl<E: Entry> Table<E> for VecTable<E> {
 	fn update(&self, _key: Self::Key, _entry: E)-> Result<(), String>{
 		unimplemented!();
 	}
-	fn query(&self, _q: QueryType,  _data:Vec<Value>, _key: Self::Key) -> Result<Vec<(Self::Key, E)>,String>{
+	fn query(&self, _q: QueryType<E>,  _key: Option<Self::Key>) -> Result<Vec<(Self::Key, E)>,String>{
 		unimplemented!();
 	}
 	

--- a/src/vec_table.rs
+++ b/src/vec_table.rs
@@ -46,17 +46,11 @@ impl<E: Entry> Table<E> for VecTable<E> {
 
     type Key = VecTableKey;
 
-    fn insert(&self, entry: E) -> Self::Key {
-        unimplemented!();
-		/*
-		//Commenting this out since it needs a mutable reference. 
-		//As in you can only use this once, and never again.
-		//Yeah nope
+    fn insert(&mut self, entry: E) -> Self::Key {
 		self.vector.push((self.next_key, entry));
         let key = VecTableKey { id: self.next_key };
         self.next_key += 1;
         key
-		*/
     }
 
     fn lookup(&self, key: Self::Key) -> Option<E> {


### PR DESCRIPTION
query can be called using it's enum, QueryType. The enum will store the necessary data that is required to perform the desired query. Because of the nature of the enum, if you don't supply the right information, it won't even compile, which will reduce programming error.  In addition, it is near impossible to make this library panic.